### PR TITLE
New-message badge on Map chat button

### DIFF
--- a/app/src/main/java/com/example/scrap7/MapViewModel.kt
+++ b/app/src/main/java/com/example/scrap7/MapViewModel.kt
@@ -26,6 +26,13 @@ class MapViewModel : ViewModel() {
     var destination by mutableStateOf<LatLng?>(null)
     private set
 
+    // --- Unread badge state ---
+    var unreadCount by mutableStateOf(0)
+    private set
+
+    var lastRead by mutableStateOf(0L)
+    private set
+
     fun setTrip(pickup: LatLng, destination: LatLng) {
         this.pickup = pickup
         this.destination = destination
@@ -85,6 +92,25 @@ class MapViewModel : ViewModel() {
             } catch (e: Exception) {
                 Log.e("VMRouteFetch", "Error: ${e.message}", e)
             }
+        }
+    }
+
+    /** Set a baseline so we don't count all historical messages on first attach */
+    fun markUnreadBaselineNowIfUnset() {
+        if (lastRead == 0L) lastRead = System.currentTimeMillis()
+    }
+
+    /** Clear badge and mark this moment as read */
+    fun clearUnread() {
+        unreadCount = 0
+        lastRead = System.currentTimeMillis()
+    }
+
+    /** Increment badge for messages from the other user that arrived after lastRead */
+    fun bumpUnreadIfNeeded(senderId: String?, timestamp: Long?, currentUserId: String) {
+        if (senderId == null || timestamp == null) return
+        if (senderId != currentUserId && timestamp > lastRead) {
+            unreadCount++
         }
     }
 }


### PR DESCRIPTION
Description
Show an unread message badge on the Map chat FAB. Increment on new messages from the other party; clear when entering Chat.

Acceptance Criteria
- Badge shows count of unread in Map screen
- Unread increments only for messages from the other user
- Opening Chat clears unread
- Route still persists when navigating back

refs #<issue-number>

closes #4 